### PR TITLE
Recommend ChatGPT-4o and document non-AI lore generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ The mod can use OpenAI for lore generation. Set your API key either in the
 environment variable. Leaving the field blank and using the environment
 variable keeps the key out of plain-text config files. Avoid committing your
 personal API key to version control.
+
+We recommend using OpenAI's ChatGPT-4o model (`openai_model: gpt-4o`) for the
+most coherent lore. When `ai_generated` is set to `true` and an API key is
+provided, lore is generated through ChatGPT-4o.
+
+If you prefer not to use AI, set `ai_generated` to `false` or omit the API key
+and the mod will fall back to its built-in generator, which creates simple
+placeholder books.

--- a/src/main/java/com/thunder/loregenerator/config/LoreConfig.java
+++ b/src/main/java/com/thunder/loregenerator/config/LoreConfig.java
@@ -19,7 +19,8 @@ public class LoreConfig {
                 .define("world_description", "The world is shattered and strange anomalies emerge from the caves.");
 
         AI_GENERATED = builder
-                .comment("Use AI to generate lore based on world_description")
+                .comment("Use OpenAI ChatGPT-4o to generate lore based on world_description. "
+                        + "Set to false to use the built-in generator instead of AI.")
                 .define("ai_generated", true);
 
         OPENAI_API_KEY = builder
@@ -27,8 +28,8 @@ public class LoreConfig {
                 .define("openai_api_key", "");
 
         OPENAI_MODEL = builder
-                .comment("Model to use for OpenAI lore generation")
-                .define("openai_model", "gpt-4o-mini");
+                .comment("Model to use for OpenAI lore generation. Recommended: gpt-4o.")
+                .define("openai_model", "gpt-4o");
 
         LORE_GENERATION_MODE = builder
                 .comment("Mode: live, fallback, or generate_and_export")

--- a/src/main/java/com/thunder/loregenerator/lore/LoreManager.java
+++ b/src/main/java/com/thunder/loregenerator/lore/LoreManager.java
@@ -11,6 +11,10 @@ public class LoreManager {
         GeneratedBook pregen = PreGeneratedLoreLoader.getBookForTags(tags);
         if (pregen != null) return CompletableFuture.completedFuture(pregen);
 
+        if (!LoreConfig.AI_GENERATED.get()) {
+            return CompletableFuture.completedFuture(LoreGenerator.generateBook(tags));
+        }
+
         String key = LoreConfig.OPENAI_API_KEY.get();
         if (key == null || key.isBlank()) {
             key = System.getenv("OPENAI_API_KEY");

--- a/src/main/java/com/thunder/loregenerator/lore/OpenAILoreGenerator.java
+++ b/src/main/java/com/thunder/loregenerator/lore/OpenAILoreGenerator.java
@@ -30,7 +30,7 @@ public class OpenAILoreGenerator {
 
             JsonObject payload = new JsonObject();
             String model = LoreConfig.OPENAI_MODEL.get();
-            payload.addProperty("model", model == null || model.isBlank() ? "gpt-4o-mini" : model);
+            payload.addProperty("model", model == null || model.isBlank() ? "gpt-4o" : model);
             payload.add("messages", messages);
             payload.addProperty("temperature", 0.8);
             payload.addProperty("max_tokens", 500);


### PR DESCRIPTION
## Summary
- Recommend using OpenAI ChatGPT-4o in config and docs
- Default to gpt-4o model and allow opting out of AI
- Document non-AI fallback in README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c02170e63c8328ab8475e63b937740