### PR TITLE
feat: refresh outdated config files

### DIFF
--- a/src/main/java/com/thunder/loregenerator/config/LoreConfig.java
+++ b/src/main/java/com/thunder/loregenerator/config/LoreConfig.java
@@ -4,6 +4,8 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 
 public class LoreConfig {
     public static final ModConfigSpec CONFIG;
+    public static final int CURRENT_VERSION = 1;
+    public static final ModConfigSpec.IntValue CONFIG_VERSION;
     public static final ModConfigSpec.ConfigValue<String> WORLD_DESCRIPTION;
     public static final ModConfigSpec.BooleanValue AI_GENERATED;
     public static final ModConfigSpec.ConfigValue<String> OPENAI_API_KEY;
@@ -13,6 +15,10 @@ public class LoreConfig {
     static {
         var builder = new ModConfigSpec.Builder();
         builder.push("server_lore");
+
+        CONFIG_VERSION = builder
+                .comment("Internal config version. Do not modify.")
+                .defineInRange("config_version", CURRENT_VERSION, 1, Integer.MAX_VALUE);
 
         WORLD_DESCRIPTION = builder
                 .comment("Brief description of your world to seed AI-generated lore")


### PR DESCRIPTION
## Summary
- add internal config version entry
- delete outdated config file before registering config to regenerate defaults

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c0265a1bd48328aa97b06cfd4cd990